### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -145,13 +145,13 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -191,6 +191,30 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 Type: `string`
 
 Default: `"argocd"`
+
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -357,8 +381,8 @@ Description: The MinIO root user password.
 |Name |Version
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
 = Resources
@@ -395,6 +419,24 @@ Description: The MinIO root user password.
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ This module is configured to used OIDC out-of-the-box, as long as the proper sco
 
 However, there is no way to configure the OIDC login as default on the login page, so take note that in order to use the OIDC login you need to click on _Other Authentication Methods_ then _Login using SSO (_)_, as shown in the screenshot below.
 
-image::login_page.png[MinIO Login Page]
+image::https://raw.githubusercontent.com/camptocamp/devops-stack-module-minio/main/docs/modules/ROOT/assets/images/login_page.png[link=https://raw.githubusercontent.com/camptocamp/devops-stack-module-minio/main/docs/modules/ROOT/assets/images/login_page.png,window=_blank]
 
 == Technical Reference
 

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "minio-${var.destination_cluster}" : "minio"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "minio"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
   timeouts {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,18 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "destination_cluster" {
   description = "Destination cluster where the application should be deployed."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:
- Adds the required variables and configuration to allow the module to be deployed on a different cluster than Argo CD.
- Adds the possibility of placing the application inside a specified Argo CD project in order to avoid having a single project for each application throughout multiple clusters.
- Adds labels and a variable to add more labels to the Argo CD application to make it easier to sort applications on the web interface of Argo CD.

**All these changes are made in preparation for having a centralized Argo CD that controls applications throughout multiple clusters.**

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD