### PR TITLE
fix: remove legacy ingress annotations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -220,7 +220,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -432,7 +432,7 @@ Description: The MinIO root user password.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/locals.tf
+++ b/locals.tf
@@ -52,8 +52,6 @@ locals {
             "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
             "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
             "traefik.ingress.kubernetes.io/router.tls"         = "true"
-            "ingress.kubernetes.io/ssl-redirect"               = "true"
-            "kubernetes.io/ingress.allow-http"                 = "false"
           }
           hosts = [
             local.domain,


### PR DESCRIPTION
## Description of the changes

The SSL redirection is no longer defined by these annotations, I think this is a leftover from ancient code. The HTTP -> HTTPS redirection is handled natively by the Traefik module and is enabled by default (a variable is available to deactivate it if necessary).

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD